### PR TITLE
Only apply mappings for Jinlon devices

### DIFF
--- a/90-custom-keyboard.hwdb
+++ b/90-custom-keyboard.hwdb
@@ -1,3 +1,3 @@
-evdev:atkbd:dmi:bvn*:bvr*:bd*:svn*:Jinlon:pvr*
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svn*:pnJinlon:pvr*
  KEYBOARD_KEY_97=!kbdillumdown
  KEYBOARD_KEY_92=scale

--- a/90-custom-keyboard.hwdb
+++ b/90-custom-keyboard.hwdb
@@ -1,3 +1,3 @@
-evdev:atkbd:dmi:bvn*:bvr*:bd*:svn*:pn*:pvr*
+evdev:atkbd:dmi:bvn*:bvr*:bd*:svn*:Jinlon:pvr*
  KEYBOARD_KEY_97=!kbdillumdown
  KEYBOARD_KEY_92=scale


### PR DESCRIPTION
This is so that the script can be run on non-jinlons without breaking anything.